### PR TITLE
fix(Profile tab): Fixed the alignment of the text and logo

### DIFF
--- a/src/components/CustomInput.tsx
+++ b/src/components/CustomInput.tsx
@@ -121,11 +121,17 @@ const CustomInput: React.FC<CustomInputProps> = ({
             aria-describedby={errorId}
             {...(fullwidth ? { fullWidth: true } : {})}
             {...inputProps}
+            sx={{
+              '.MuiSelect-select': {
+                display: "flex",
+                alignItems: "center",
+              }
+            }}
           >
             {options?.map((option) => (
               <MenuItem key={option.value} value={option.value}>
                 {option.src && (
-                  <img loading="lazy" width="20" src={option.src} srcSet={`${option.src} 2x`} alt="flag" style={{ marginRight: 8 }} />
+                  <img loading="lazy" src={option.src} srcSet={`${option.src} 2x`} alt="flag" style={{ height: "14px", aspectRatio: 1, objectFit: "fill", marginRight: "4px"}} />
                 )}
                 {option.label}
               </MenuItem>

--- a/src/components/FormSection.tsx
+++ b/src/components/FormSection.tsx
@@ -16,6 +16,7 @@ export type FormField<T> = {
   xs?: number; // Grid size for extra small screens.
   sm?: number; // Grid size for small screens.
   defaultValue?: any; // Default value for the field.
+  sx?: any; // Style object for the field.
 };
 
 interface FormSectionProps<T extends FieldValues> {
@@ -42,6 +43,9 @@ interface FormSectionProps<T extends FieldValues> {
 
   /** Default value for the field. */
   defaultValue?: any;
+
+  /** sx . */
+  sx?: any;
 }
 
 /**
@@ -55,7 +59,8 @@ export default function FormSection<T extends Record<string, any>>({
   childrenForInput,
   showPassword,
   handleToggleVisibility,
-  defaultValue
+  defaultValue,
+  sx
 }: FormSectionProps<T>) {
   return (
     <>
@@ -80,6 +85,7 @@ export default function FormSection<T extends Record<string, any>>({
                   showPassword={showPassword}
                   handleToggleVisibility={handleToggleVisibility}
                   defaultValue={defaultValue}
+                  sx={sx}
                 >
                   {/* Render the specific component for specific field */}
                   {(childrenForInput && childrenForInput[field.name]) || null}

--- a/src/pages/account/settings/settingsTab.tsx
+++ b/src/pages/account/settings/settingsTab.tsx
@@ -32,12 +32,11 @@ export default function SettingsTab() {
           <Grid item xs={12} sm={6} key={group.id}>
             <MainCard divider title={group.cardTitle}>
               <Box sx={{ mb: 3 }}>
-                <Typography variant="h6">{group.cardTitle}</Typography>
-                <Typography variant="body2" color="text.secondary">
+                <Typography variant="h6">
                   {group.cardDescription}
                 </Typography>
               </Box>
-              <FormSection<SettingsFormDataType> fields={group.fields} control={control} errors={errors} defaultValue={defaultValues} />
+              <FormSection<SettingsFormDataType> fields={group.fields} control={control} errors={errors} defaultValue={defaultValues} sx={{ display: "flex", justifyContent: "space-between", color: theme.palette.grey[500] }} />
             </MainCard>
           </Grid>
         ))}


### PR DESCRIPTION
- Fixed the alignment of the text and logo.
- Also solved minor issue in settings tab. 
![image](https://github.com/user-attachments/assets/794cec5a-b0c0-4c67-9ba7-984b0c04f546)

Closes #35 
